### PR TITLE
Update west.yml golioth import

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -14,9 +14,7 @@ manifest:
       path: modules/lib/golioth
       revision: main
       url: https://github.com/golioth/zephyr-sdk.git
-      import:
-        name-allowlist:
-          - qcbor
+      import: west-external.yml
     # Pyrinas backend
     - name: pyrinas
       url: https://github.com/pyrinas-iot/pyrinas-zephyr


### PR DESCRIPTION
Goloith no longer has a `west.yml` which causes [this issue](https://github.com/golioth/golioth-zephyr-sdk/issues/198) when initializing this project.