### PR TITLE
Update Golioth API

### DIFF
--- a/samples/tracker/conf/backends/golioth.conf
+++ b/samples/tracker/conf/backends/golioth.conf
@@ -28,3 +28,6 @@ CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED=n
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
 # ... also increase heap size to "high enough to make it work"
 CONFIG_MBEDTLS_HEAP_SIZE=49152
+
+# Enable remote logging on Golioth
+CONFIG_LOG_BACKEND_GOLIOTH=y

--- a/west.yml
+++ b/west.yml
@@ -25,7 +25,7 @@ manifest:
     # Golioth backend
     - name: golioth
       path: modules/lib/golioth
-      revision: 9e02125bffff0c0377595f3e05c30e40d1d2cb1b
+      revision: v0.6.0
       url: https://github.com/golioth/golioth-zephyr-sdk
       import: west-external.yml
     # Pyrinas backend


### PR DESCRIPTION
Golioth API calls for Stream and State data were changed in Golioth Zephyr SDK v0.4.0 on October 19, 2022. This PR updates the Golioth SDK to v0.6.0 and changes function calls to the most recent API format.

Also included in this PR is the additional Kconfig symbol `CONFIG_LOG_BACKEND_GOLIOTH` which sends log messages to Golioths remote logging service.