### PR TITLE
NCS v3.1.1 build fixes

### DIFF
--- a/boards/circuitdojo/feather_nrf9161/startup.c
+++ b/boards/circuitdojo/feather_nrf9161/startup.c
@@ -1,7 +1,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/drivers/mfd/npm1300.h>
+#include <zephyr/drivers/mfd/npm13xx.h>
 LOG_MODULE_REGISTER(app_startup);
 
 #define SYSREG_VBUSIN_BASE 0x02
@@ -22,7 +22,7 @@ static int sysreg_setup(void)
     }
 
     uint8_t data = 0;
-    int ret = mfd_npm1300_reg_read_burst(pmic, SYSREG_VBUSIN_BASE, SYSREG_VBUSINILIM0, &data, 1);
+    int ret = mfd_npm13xx_reg_read_burst(pmic, SYSREG_VBUSIN_BASE, SYSREG_VBUSINILIM0, &data, 1);
     if (ret < 0)
     {
         printk("Failed to read VBUSINLIM. Err: %d", ret);
@@ -41,7 +41,7 @@ static int sysreg_setup(void)
     }
 
     /* Write to MFD to set SYSREG current to 500mA */
-    ret = mfd_npm1300_reg_write(pmic, SYSREG_VBUSIN_BASE, SYSREG_VBUSINILIM0, 0);
+    ret = mfd_npm13xx_reg_write(pmic, SYSREG_VBUSIN_BASE, SYSREG_VBUSINILIM0, 0);
     if (ret < 0)
     {
         printk("Failed to set VBUSINLIM. Err: %d\n", ret);
@@ -49,7 +49,7 @@ static int sysreg_setup(void)
     }
 
     /* Save and update */
-    ret = mfd_npm1300_reg_write(pmic, SYSREG_VBUSIN_BASE, SYSREG_TASKUPDATEILIMSW, 0x01);
+    ret = mfd_npm13xx_reg_write(pmic, SYSREG_VBUSIN_BASE, SYSREG_TASKUPDATEILIMSW, 0x01);
     if (ret < 0)
     {
         printk("Failed to save settings. Err: %d\n", ret);

--- a/samples/active_sleep/src/main.c
+++ b/samples/active_sleep/src/main.c
@@ -44,7 +44,7 @@ static const struct gpio_dt_spec hold =
 #endif
 
 #if IS_ENABLED(CONFIG_REGULATOR_NPM13XX)
-// static const struct device *buck2 = DEVICE_DT_GET(DT_NODELABEL(npm1300_buck2));
+static const struct device *buck2 = DEVICE_DT_GET(DT_NODELABEL(npm1300_buck2));
 #endif
 
 static void setup_accel(void)

--- a/samples/serial_lte_modem/CMakeLists.txt
+++ b/samples/serial_lte_modem/CMakeLists.txt
@@ -21,6 +21,8 @@ target_sources(app PRIVATE ../../../nrf/applications/serial_lte_modem/src/slm_at
 target_sources(app PRIVATE ../../../nrf/applications/serial_lte_modem/src/slm_at_icmp.c)
 target_sources(app PRIVATE ../../../nrf/applications/serial_lte_modem/src/slm_at_fota.c)
 target_sources(app PRIVATE ../../../nrf/applications/serial_lte_modem/src/slm_uart_handler.c)
+target_sources(app PRIVATE ../../../nrf/applications/serial_lte_modem/src/slm_ctrl_pin.c)
+
 # NORDIC SDK APP END
 target_sources_ifdef(CONFIG_SLM_SMS app PRIVATE ../../../nrf/applications/serial_lte_modem/src/slm_at_sms.c)
 target_sources_ifdef(CONFIG_SLM_PPP app PRIVATE ../../../nrf/applications/serial_lte_modem/src/slm_ppp.c)

--- a/samples/usb_detect/src/main.c
+++ b/samples/usb_detect/src/main.c
@@ -139,14 +139,14 @@ static int buck2_set_mode(bool enabled)
 
 static void event_callback(const struct device *dev, struct gpio_callback *cb, uint32_t pins)
 {
-  if (pins & BIT(NPM1300_EVENT_VBUS_DETECTED))
+  if (pins & BIT(NPM13XX_EVENT_VBUS_DETECTED))
   {
     LOG_DBG("Vbus connected");
     vbus_connected = true;
     k_sem_give(&usb_detect_sem);
   }
 
-  if (pins & BIT(NPM1300_EVENT_VBUS_REMOVED))
+  if (pins & BIT(NPM13XX_EVENT_VBUS_REMOVED))
   {
     LOG_DBG("Vbus removed");
     vbus_connected = false;
@@ -212,8 +212,8 @@ int main(void)
   static struct gpio_callback event_cb;
 
   gpio_init_callback(&event_cb, event_callback,
-                     BIT(NPM1300_EVENT_VBUS_DETECTED) |
-                         BIT(NPM1300_EVENT_VBUS_REMOVED));
+                     BIT(NPM13XX_EVENT_VBUS_DETECTED) |
+                         BIT(NPM13XX_EVENT_VBUS_REMOVED));
 
   mfd_npm13xx_add_callback(pmic, &event_cb);
 


### PR DESCRIPTION
- Replace relevant 'npm1300' references with 'npm13xx'
- Add CMake target source `slm_ctrl_pin.c` to serial_lte_modem sample