### PR TITLE
sysbuild: allow app override of static partitions

### DIFF
--- a/boards/circuitdojo/feather_nrf9151/sysbuild.cmake
+++ b/boards/circuitdojo/feather_nrf9151/sysbuild.cmake
@@ -4,5 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_LIST_DIR}/circuitdojo_feather_nrf9151_pm_static.yml CACHE INTERNAL "")
+if (CONFIG_CIRCUITDOJO_FEATHER_NRF9151_STATIC_PARTITIONS_FACTORY)
+  set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_LIST_DIR}/circuitdojo_feather_nrf9151_pm_static.yml CACHE INTERNAL "")
+endif()
 


### PR DESCRIPTION
Guard the CircuitDojo Feather nRF9151 static partition layout in `sysbuild.cmake` behind the `CONFIG_CIRCUITDOJO_FEATHER_NRF9151_STATIC_PARTITIONS_FACTORY` Kconfig option.

`sysbuild.cmake` currently sets `PM_STATIC_YML_FILE` unconditionally, which causes the `circuitdojo_feather_nrf9151_pm_static.yml` to always take precedence during sysbuild builds. This prevents applications from supplying their own static partition layout, even when the factory partitions option is not enabled.

This change aligns sysbuild behavior with the existing Kconfig option and allows application-level partition overrides to work as expected.