### PR TITLE
boards: add Feather header gpio-map for nRF9151

### DIFF
--- a/boards/circuitdojo/feather_nrf9151/circuitdojo_feather_nrf9151_common.dtsi
+++ b/boards/circuitdojo/feather_nrf9151/circuitdojo_feather_nrf9151_common.dtsi
@@ -38,6 +38,35 @@
 		ext-flash = &w25q128jv;
 	};
 
+	/* Used for accessing other pins */
+	feather_header: feather_connector {
+		compatible = "adafruit-feather-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <12 0 &gpio0 2 0>,  /* SDA */
+		<13 0 &gpio0 1 0>,   /* SCL */
+		<14 0 &gpio0 26 0>,  /* D2 */
+		<15 0 &gpio0 27 0>,  /* D3 */
+		<16 0 &gpio0 28 0>,  /* D4 */
+		<17 0 &gpio0 29 0>,  /* D5 */
+		<18 0 &gpio0 30 0>,  /* D6 */
+		<19 0 &gpio0 31 0>,  /* D7 */
+		<20 0 &gpio0 0 0>,   /* D8 */
+		<11 0 &gpio0 25 0>,  /* EXTRA */
+		<10 0 &gpio0 24 0>,  /* TX */
+		<9 0 &gpio0 23 0>,   /* RX */
+		<8 0 &gpio0 22 0>,   /* CIPO */
+		<7 0 &gpio0 21 0>,   /* COPI */
+		<6 0 &gpio0 20 0>,   /* SCK */
+		<5 0 &gpio0 18 0>,   /* A5 */
+		<4 0 &gpio0 17 0>,   /* A4 */
+		<3 0 &gpio0 16 0>,   /* A3 */
+		<2 0 &gpio0 15 0>,   /* A2 */
+		<1 0 &gpio0 14 0>,   /* A1 */
+		<0 0 &gpio0 13 0>;   /* A0 */
+	};
+
 	fstab {
 		compatible = "zephyr,fstab";
 		lfs: lfs {


### PR DESCRIPTION
Add an adafruit-feather-header connector node and map the Feather logical pins to nRF GPIOs.